### PR TITLE
Bump references to Develocity Maven extension from 1.21.3 to 1.21.4

### DIFF
--- a/custom-maven-distribution/create-custom-maven-distribution.sh
+++ b/custom-maven-distribution/create-custom-maven-distribution.sh
@@ -32,7 +32,7 @@ maven_conf=${maven_dir}/conf
 custom_maven_version=1.0.0
 custom_maven_zip=${maven_dir}-sample-${custom_maven_version}-bin.zip
 
-develocity_ext_version=1.21.3
+develocity_ext_version=1.21.4
 develocity_ext_jar=develocity-maven-extension-${develocity_ext_version}.jar
 
 develocity_sample_ext_version=2.0

--- a/quarkus-build-caching-extension/README.md
+++ b/quarkus-build-caching-extension/README.md
@@ -33,7 +33,7 @@ Reference the extension in `.mvn/extensions.xml` (this extension requires the de
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>develocity-maven-extension</artifactId>
-        <version>1.21.3</version>
+        <version>1.21.4</version>
     </extension>
     <extension>
         <groupId>com.gradle</groupId>

--- a/rollout-maven-extension/.mvn/extensions.xml
+++ b/rollout-maven-extension/.mvn/extensions.xml
@@ -7,7 +7,7 @@
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>develocity-maven-extension</artifactId>
-        <version>1.21.3</version>
+        <version>1.21.4</version>
     </extension>
     <extension>
         <groupId>com.gradle</groupId>


### PR DESCRIPTION
This PR bumps references to the Develocity Maven extension from 1.21.3 to 1.21.4.